### PR TITLE
プロパティリストのデザイン修正

### DIFF
--- a/node/src/style/style.scss
+++ b/node/src/style/style.scss
@@ -82,12 +82,12 @@ $breadcrumbs-height: 47px;
   }
 }
 
-div:after,
-ul:after {
-  content: "";
-  display: block;
-  clear: both;
-}
+// div:after,
+// ul:after {
+//   content: "";
+//   display: block;
+//   clear: both;
+// }
 
 html {
   height: 100%;
@@ -246,7 +246,10 @@ body {
           line-height: 16px;
           list-style-type: none;
           padding: 0 0 16px 16px;
-
+          justify-content: space-between;
+          align-items: center;
+          padding-right: 12px;
+          font-weight: bold;
           .text {
             display: inline-block;
             font-size: 14px;
@@ -258,10 +261,6 @@ body {
             width: auto;
           }
 
-          li:last-child {
-            margin-left: auto;
-            margin-right: 40px;
-          }
         }
       }
 
@@ -320,6 +319,7 @@ body {
                   display: inline-block;
                   width: 18px;
                   height: 18px;
+                  line-height: 18px;
                   text-align: center;
                   border-radius: 3px;
                   color: white;

--- a/node/src/ts/visualizer/components/PropertyList.tsx
+++ b/node/src/ts/visualizer/components/PropertyList.tsx
@@ -39,11 +39,6 @@ const PropertyList: React.FC<PropertyListProps> = (props) => {
         </h2>
         <ul className="legend">
           <li>
-            <span className="legend-label">
-              <FormattedMessage id="propertyList.legend.label" />
-            </span>
-          </li>
-          <li>
             <span className="text">
               <FormattedMessage id="propertyList.legend.text" />
             </span>

--- a/node/src/ts/visualizer/locales/en.ts
+++ b/node/src/ts/visualizer/locales/en.ts
@@ -36,7 +36,6 @@ const messages = {
   'legend.class.parent': 'Parent class',
   'propertyList.hideableWrapper.target': 'Property',
   'propertyList.title': 'Properties in the dataset',
-  'propertyList.legend.label': 'Legend',
   'propertyList.legend.text': 'Property',
   'propertyList.legend.tripleCount': 'Triple count',
   'searchBox.input.placeholder.search': 'Search',

--- a/node/src/ts/visualizer/locales/ja.ts
+++ b/node/src/ts/visualizer/locales/ja.ts
@@ -35,7 +35,6 @@ const messages = {
   'legend.class.parent': '親クラス',
   'propertyList.hideableWrapper.target': 'プロパティ',
   'propertyList.title': 'データセット内プロパティ',
-  'propertyList.legend.label': '凡例',
   'propertyList.legend.text': 'プロパティ名',
   'propertyList.legend.tripleCount': 'トリプルの数',
   'searchBox.input.placeholder.search': '検索する',


### PR DESCRIPTION
左ペイン上の「凡例」をトル。「プロパティ名」「トリプルの数」をboldにする。
https://www.pivotaltracker.com/story/show/180972179

<img width="149" alt="スクリーンショット 2022-02-12 19 33 54" src="https://user-images.githubusercontent.com/2044262/153707842-6a4c99a5-4ed0-4445-a1ee-c9163410064c.png">

↓

<img width="317" alt="スクリーンショット 2022-02-12 19 31 43" src="https://user-images.githubusercontent.com/2044262/153707806-ca7ef613-ae6f-4196-a2f7-c3bec3978e3c.png">
